### PR TITLE
DBAL-0004 rename Stock.id to Stock.stockId

### DIFF
--- a/src/main/java/com/balionis/dainius/sps/model/Stock.java
+++ b/src/main/java/com/balionis/dainius/sps/model/Stock.java
@@ -17,7 +17,7 @@ public class Stock {
     @GeneratedValue(generator = "UUID")
     @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
     @Column(name = "stock_id", columnDefinition = "CHAR(36)")
-    private String id;
+    private String stockId;
 
     @Column(name = "ticker")
     private String ticker;
@@ -75,7 +75,7 @@ public class Stock {
 
 
     public String getStockId() {
-        return id;
+        return stockId;
     }
 
     public String getTicker() {
@@ -98,8 +98,8 @@ public class Stock {
         return updatedAt;
     }
 
-    public void setStockId(String id) {
-        this.id = id;
+    public void setStockId(String stockId) {
+        this.stockId = stockId;
     }
 
     public void setTicker(String ticker) {

--- a/src/main/java/com/balionis/dainius/sps/repository/PriceRepository.java
+++ b/src/main/java/com/balionis/dainius/sps/repository/PriceRepository.java
@@ -2,14 +2,15 @@ package com.balionis.dainius.sps.repository;
 
 import com.balionis.dainius.sps.model.Price;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.UUID;
 
 @Repository
 public interface PriceRepository extends JpaRepository<Price, Long> {
+    @Query("select p from Price p where p.stock.stockId = ?1 AND p.pricingDate >= ?2 AND p.pricingDate <= ?3")
     List<Price> findByStockIdAndPricingDateBetween(String stockId, LocalDate fromDate, LocalDate toDate);
 }
 

--- a/src/main/java/com/balionis/dainius/sps/repository/StockRepository.java
+++ b/src/main/java/com/balionis/dainius/sps/repository/StockRepository.java
@@ -9,10 +9,10 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface StockRepository extends JpaRepository<Stock, Long> {
+public interface StockRepository extends JpaRepository<Stock, String> {
     List<Stock> findByTickerContaining(String ticker);
     Stock findByTicker(String ticker);
 
-    Optional<Stock> findById(UUID id);
+    Optional<Stock> findById(String id);
 }
 


### PR DESCRIPTION
This PR shows how you can standardise the naming conventions working around legacy Hibernate approach of Model key always having primary key field named only "id".

This PR also fixes primary key type  you use in StockRepository. (not Long, not UUID, but String as you have defined it in "Stock.id")